### PR TITLE
update slack token retrieval tooltip

### DIFF
--- a/views/result_actions.erb
+++ b/views/result_actions.erb
@@ -25,7 +25,7 @@
       <a class='btn' title='Help' onclick='$(this).next().toggle();'><i class='fa fa-question-circle-o'></i></a>
       <p class='toggle'>A Slack user token. Available to all logged-in slack users by searching the source for "api_token", or by running the following on any *.slack.com/* page:
         <code>
-          window.prompt("your api token is: ",/api_token: "(.*)"/.exec(document.body.innerHTML)[1])
+          window.prompt("your api token is: ", window.boot_data.api_token)
         </code>
       </p>
       <label for='slackToken'>Slack User Token</label>


### PR DESCRIPTION
* Slack no longer keeps this info in a super long string, it's organized into a nice lil json!
* the old way of executing a regex to find a user token no longer works
* this way does

:chicken_eyebrows: